### PR TITLE
Bigger pos variable

### DIFF
--- a/EncoderStepCounter.cpp
+++ b/EncoderStepCounter.cpp
@@ -105,7 +105,7 @@ void EncoderStepCounter::tick() {
 }
 
 // Getter and Setter
-signed char EncoderStepCounter::getPosition() const {
+signed int EncoderStepCounter::getPosition() const {
   return encoderpos;
 }
 void EncoderStepCounter::setPosition(signed char aPosition) {

--- a/EncoderStepCounter.h
+++ b/EncoderStepCounter.h
@@ -26,7 +26,7 @@ enum EncoderType: unsigned char { HALF_STEP, FULL_STEP };
 class EncoderStepCounter {
 public:
   EncoderStepCounter(int aPin1, int aPin2, EncoderType aEncType = FULL_STEP);
-  signed char getPosition() const;
+  signed int getPosition() const;
   void setPosition(signed char aPosition);
   void reset();
   void tick();
@@ -52,7 +52,7 @@ private:
   EncDir last_zero_dir;
 
   // Attribute for current position
-  signed volatile char encoderpos;
+  signed volatile int encoderpos;
 
   // Helper to get current encoder position
   bool CheckEncoderPos(bool& aPosValue, EncDir& aDirection);


### PR DESCRIPTION
position variable modified int instead of char, getPosition modified to int from char
This will protect the position to be overloaded when more than 127 steps are counted before encoder gets reset.